### PR TITLE
Fix the delivery pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
           BOLDRED=$(tput bold && tput setaf 1)
           RESET=$(tput sgr0)
           echo "${BOLDRED}==> We won't fail on formatting errors for the time being, but we will in the future.${RESET}"
-      
+
       - name: Check lint
         run: |
           make check-lint || true
@@ -72,7 +72,7 @@ jobs:
 
       - name: Check Dockerfile
         run: make check-docker
-          
+
       - name: Build Docker image
         run: make build-image
 
@@ -98,7 +98,7 @@ jobs:
       - name: Check version matching the tag
         shell: bash
         run: make docs
-      
+
       - name: Upload documentation
         uses: actions/upload-artifact@v4
         with:
@@ -124,7 +124,7 @@ jobs:
 
       - name: Prepare virtual environment
         run: make create-env
-      
+
       - name: Check version matching the tag
         run: make check-version
 
@@ -145,24 +145,21 @@ jobs:
 
       - name: Prepare virtual environment
         run: make create-env
-      
+
       - name: Download packages
         uses: actions/download-artifact@v4
         with:
           name: python-packages
-      
+
       - name: Publish to PyPI
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        if: ${{ env.PYPI_TOKEN != '' }}
         run: make publish-dist
 
   docker-push:
     name: Push Docker image
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    env:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     needs:
       - check-version
 
@@ -175,10 +172,14 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Prepare virtual environment
+        run: make create-env
+
       - name: Login to DockerHub
-        if: ${{ env.DOCKER_USERNAME != '' }}
-        run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: make docker-login
 
       - name: Push Docker image
-        if: ${{ env.DOCKER_USERNAME != '' }}
         run: make push-image


### PR DESCRIPTION
- It doesn't skip any delivery job step when the required secrets are missing, but fail.
- It makes sure that the python virtual environment is created before calculating the package version.
- The package version and the docker image are moved into a function to make sure that they are calculated after the target requirements are run.
- Adds a new Makefile target for login into DockerHub.